### PR TITLE
Crashing python3.5 zip and main.c 

### DIFF
--- a/PythonAndroid/app/src/main/assets/pythonforandroid.py
+++ b/PythonAndroid/app/src/main/assets/pythonforandroid.py
@@ -1,2 +1,5 @@
 def add_func(a,b):
     return a+b
+
+def get_stream(ytid):
+    return "Hello"

--- a/PythonAndroid/jni/main.c
+++ b/PythonAndroid/jni/main.c
@@ -24,16 +24,21 @@ JNIEXPORT jint JNICALL Java_com_example_pythontest_MainActivity_add
     //add current path to search pythonforandroid.py file
     PyRun_SimpleString("import sys");
     PyRun_SimpleString("sys.path.append('/data/data/com.example.pythontest/files')"); //this mean pythonforandroid.py under /data/data/com.example.pythontest/files
+    // PyRun_SimpleString("print('hello')"); //this mean pythonforandroid.py under /data/data/com.example.pythontest/files
 
     PyObject *pModule;
     PyObject *pFunction;
+    PyObject *ytFunction;
     PyObject *pArgs;
+    PyObject *ytArgs;
     PyObject *pRetValue;
+    PyObject *ytRetValue;
+    // PyObject *streamLink;
 
     //import module which name pythonforandroid under /data/data/com.example.pythontest/files
     pModule = PyImport_ImportModule("pythonforandroid");
     if(!pModule){
-    	__android_log_print(ANDROID_LOG_INFO, "JNIEnv","import python failed!!\n"); 
+    	__android_log_print(ANDROID_LOG_INFO, "JNIEnv","import python module failed!!\n"); 
         return -1;
     }
 
@@ -41,18 +46,34 @@ JNIEXPORT jint JNICALL Java_com_example_pythontest_MainActivity_add
     pFunction = PyObject_GetAttrString(pModule, "add_func");
     if(!pFunction){ 
     	__android_log_print(ANDROID_LOG_INFO, "JNIEnv","get python function failed!!!\n"); 
-    	return -1;    }
+    	return -1;    
+    }
     pArgs = PyTuple_New(2);
     PyTuple_SetItem(pArgs, 0, Py_BuildValue("i", arg0));
     PyTuple_SetItem(pArgs, 1, Py_BuildValue("i", arg1));
     pRetValue = PyObject_CallObject(pFunction, pArgs);
 
-    __android_log_print(ANDROID_LOG_INFO, "JNIEnv","PyImport_ImportModule %ld",PyLong_AsLong(pRetValue)); 
+    __android_log_print(ANDROID_LOG_INFO, "JNIEnv","pRetValue %ld",PyLong_AsLong(pRetValue)); 
+
+    ytFunction = PyObject_GetAttrString(pModule, "get_stream");
+
+    if(!ytFunction){ 
+        __android_log_print(ANDROID_LOG_INFO, "JNIEnv","get yt function failed!!!\n"); 
+        return -1;    
+    }
+    ytArgs = PyTuple_New(1);
+    PyTuple_SetItem(ytArgs, 0, Py_BuildValue("s", arg0));
+    ytRetValue = PyObject_CallObject(ytFunction, ytArgs);
+    // streamLink = PyDict_GetItemString(ytRetValue, "stream");
+    __android_log_print(ANDROID_LOG_INFO, "JNIEnv","pRetValue %s", PyUnicode_AsUTF8(ytRetValue)); 
 
     Py_DECREF(pModule);
     Py_DECREF(pFunction);
+    Py_DECREF(ytFunction);
     Py_DECREF(pArgs);
+    Py_DECREF(ytArgs);
     Py_DECREF(pRetValue);
+    Py_DECREF(ytRetValue);
     Py_Finalize();
     
     return PyLong_AsLong(pRetValue);


### PR DESCRIPTION
I have two scenarios here that I can produce crashes on. I wanted to give you the files that I was using so it is easier to reproduce for you. 

I have added python3.5_mod.zip which contains the youtube_dl library which cause the python3 in adb shell to crash for me. 

output from shell

```
root@hammerhead:/ # python3
Could not find platform independent libraries <prefix>
Could not find platform dependent libraries <exec_prefix>
Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]
Fatal Python error: Py_Initialize: can't initialize sys standard streams
ImportError: No module named 'encodings'

Current thread 0xb6d3db34 (most recent call first):
Aborted
```

I have also added a main.c file which is crashing my APK. I am creating a new function and simply returning a string. Maybe I am doing something wrong here with the Python C API? 

The output from logcat:

```
04-26 22:04:36.516 2726-2726/com.example.pythontest I/JNIEnv: Py_Initialize successfully!!
04-26 22:04:36.527 2726-2726/com.example.pythontest I/JNIEnv: pRetValue 68
04-26 22:04:36.528 2726-2726/com.example.pythontest A/libc: Fatal signal 11 (SIGSEGV), code 1, fault addr 0x17 in tid 2726 (mple.pythontest)
```
